### PR TITLE
Improve totem visibility and visual feedback

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -41,7 +41,7 @@ addon.defaults = {
     disablePopupInCombat = false, -- Completely disable popup bars in combat (not just hide)
     showTooltips = true, -- Show tooltips on hover
     showGroupBuffCount = true, -- Show group buff count next to timers/tooltips
-    showGroupBuffStyle = "numbers", -- "numbers" or "dots"
+    showGroupBuffStyle = "dots", -- "dots" only
     showMinimapButton = true, -- Show minimap button
     minimapButtonPos = 220, -- Angle in degrees
     totemExpirySound = true, -- Master enable/disable expiry sounds
@@ -256,7 +256,7 @@ end
 function addon.GetTotemBySpellID(spellID)
     for element, totems in pairs(addon.TOTEMS) do
         for _, totem in ipairs(totems) do
-            if totem.spellID == spellID then
+            if totem.spellID == spellID then2
                 return totem, element
             end
         end
@@ -470,7 +470,7 @@ function addon.FormatGroupBuffCount(buffed, total)
         return nil
     end
 
-    local style = TotemDeckDB and TotemDeckDB.showGroupBuffStyle or "numbers"
+    local style = TotemDeckDB and TotemDeckDB.showGroupBuffStyle or "dots"
     if style == "dots" then
         local filledDot = "|TInterface\\COMMON\\Indicator-Green:16:16:0:0|t"
         local emptyDot = "|TInterface\\COMMON\\Indicator-Gray:16:16:0:0|t"

--- a/Core.lua
+++ b/Core.lua
@@ -40,6 +40,10 @@ addon.defaults = {
     barScale = 1.0, -- Scale factor for the action bar
     disablePopupInCombat = false, -- Completely disable popup bars in combat (not just hide)
     showTooltips = true, -- Show tooltips on hover
+    showGroupBuffCount = true, -- Show group buff count next to timers/tooltips
+    showGroupBuffStyle = "numbers", -- "numbers" or "dots"
+    showMinimapButton = true, -- Show minimap button
+    minimapButtonPos = 220, -- Angle in degrees
     totemExpirySound = true, -- Master enable/disable expiry sounds
     totemExpirySoundIDs = { -- Per-element sound IDs (0 = None)
         Earth = 8959,
@@ -207,6 +211,7 @@ addon.state = {
     totemSoundPlayed = { -- Track per-slot to prevent spam
         [1] = false, [2] = false, [3] = false, [4] = false
     },
+    totemLastStart = {},
 }
 
 -- Utility: Check if player is a Shaman
@@ -320,10 +325,11 @@ function addon.IsPopupModifierPressed()
     return true
 end
 
--- Check if player has the buff from a totem (for out-of-range detection)
+-- Check if a unit has the buff from a totem (for out-of-range detection)
 -- Returns: true = has buff (in range), false = no buff (out of range), nil = totem doesn't provide a buff
--- Now accepts either spellID or localized totem name
-function addon.HasTotemBuff(totemIdentifier)
+-- Accepts either spellID or localized totem name; unit defaults to "player"
+function addon.HasTotemBuff(totemIdentifier, unit)
+    unit = unit or "player"
     local spellID
     if type(totemIdentifier) == "number" then
         spellID = totemIdentifier
@@ -356,9 +362,9 @@ function addon.HasTotemBuff(totemIdentifier)
     local totemName = addon.GetTotemName(spellID)
     if not totemName then return nil end
 
-    -- Check if player has the buff (using localized name)
+    -- Check if unit has the buff (using localized name)
     for i = 1, 40 do
-        local name = UnitBuff("player", i)
+        local name = UnitBuff(unit, i)
         if not name then break end
         -- Check for exact match or partial match (buff name may be shorter)
         if name == totemName or totemName:find(name, 1, true) or name:find(totemName:gsub(" Totem$", ""), 1, true) then
@@ -366,6 +372,120 @@ function addon.HasTotemBuff(totemIdentifier)
         end
     end
     return false
+end
+
+-- Count how many group members currently have a totem buff
+-- Returns: buffedCount, totalCount, or nil if not in group/raid or not a buff-providing totem
+function addon.GetGroupTotemBuffCount(totemIdentifier)
+    -- Resolve spell ID to determine if this totem provides a buff
+    local spellID
+    if type(totemIdentifier) == "number" then
+        spellID = totemIdentifier
+    else
+        local name, _, _, _, _, _, sid = GetSpellInfo(totemIdentifier)
+        spellID = sid
+        if not spellID then
+            for element, totems in pairs(addon.TOTEMS) do
+                for _, totem in ipairs(totems) do
+                    local totemName = addon.GetTotemName(totem.spellID)
+                    local baseName = totemIdentifier:gsub("%s+[IVXLCDM]+$", "")
+                    if totemName and totemName:find(baseName, 1, true) then
+                        spellID = totem.spellID
+                        break
+                    end
+                end
+                if spellID then break end
+            end
+        end
+    end
+
+    if not spellID or not addon.TOTEM_PROVIDES_BUFF[spellID] then
+        return nil
+    end
+
+    local total = 0
+    local buffed = 0
+
+    if IsInRaid() then
+        local num = GetNumGroupMembers()
+        local playerGroup = nil
+        for i = 1, num do
+            local unit = "raid" .. i
+            if UnitExists(unit) and UnitIsUnit(unit, "player") then
+                local _, _, subgroup = GetRaidRosterInfo(i)
+                playerGroup = subgroup
+                break
+            end
+        end
+        for i = 1, num do
+            local unit = "raid" .. i
+            if UnitExists(unit) then
+                local _, _, subgroup = GetRaidRosterInfo(i)
+                if not playerGroup or subgroup == playerGroup then
+                    total = total + 1
+                    if addon.HasTotemBuff(totemIdentifier, unit) then
+                        buffed = buffed + 1
+                    end
+                end
+            end
+        end
+    elseif IsInGroup() then
+        -- Party (includes player)
+        if UnitExists("player") then
+            total = total + 1
+            if addon.HasTotemBuff(totemIdentifier, "player") then
+                buffed = buffed + 1
+            end
+        end
+        local num = GetNumSubgroupMembers()
+        for i = 1, num do
+            local unit = "party" .. i
+            if UnitExists(unit) then
+                total = total + 1
+                if addon.HasTotemBuff(totemIdentifier, unit) then
+                    buffed = buffed + 1
+                end
+            end
+        end
+    else
+        -- Solo: return player's buff status as 1/1
+        if UnitExists("player") then
+            total = 1
+            if addon.HasTotemBuff(totemIdentifier, "player") then
+                buffed = 1
+            end
+        end
+    end
+
+    if total == 0 then
+        return nil
+    end
+
+    return buffed, total
+end
+
+-- Format group buff count for display
+function addon.FormatGroupBuffCount(buffed, total)
+    if not buffed or not total then
+        return nil
+    end
+
+    local style = TotemDeckDB and TotemDeckDB.showGroupBuffStyle or "numbers"
+    if style == "dots" then
+        local filledDot = "|TInterface\\COMMON\\Indicator-Green:16:16:0:0|t"
+        local emptyDot = "|TInterface\\COMMON\\Indicator-Gray:16:16:0:0|t"
+        local dots = {}
+        for i = 1, total do
+            if i <= buffed then
+                dots[#dots + 1] = filledDot
+            else
+                dots[#dots + 1] = emptyDot
+            end
+        end
+        return table.concat(dots, "\n"), false
+    end
+
+    return tostring(buffed) .. "/" .. tostring(total), true
 end
 
 -- Check if a weapon buff spell is known (accepts spell ID)

--- a/Core.lua
+++ b/Core.lua
@@ -256,7 +256,7 @@ end
 function addon.GetTotemBySpellID(spellID)
     for element, totems in pairs(addon.TOTEMS) do
         for _, totem in ipairs(totems) do
-            if totem.spellID == spellID then2
+            if totem.spellID == spellID then
                 return totem, element
             end
         end

--- a/Events.lua
+++ b/Events.lua
@@ -311,7 +311,7 @@ timerUpdateFrame:SetScript("OnUpdate", function(self, delta)
             addon.UpdateTimers()
         end
         -- Update weapon buff timer
-        if addon.UI.weaponBuffButton then
+        if addon.UI and addon.UI.weaponBuffButton then
             addon.UpdateWeaponBuffButton()
         end
     end

--- a/Events.lua
+++ b/Events.lua
@@ -175,6 +175,7 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, arg2, arg3)
         addon.CreateActionBarFrame()
         addon.CreateTimerFrame()
         addon.SetupPopupSystem()
+        addon.CreateMinimapButton()
 
         -- Show popup if always show is enabled
         if TotemDeckDB.alwaysShowPopup then

--- a/Events.lua
+++ b/Events.lua
@@ -99,6 +99,9 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1, arg2, arg3)
             end
         end
 
+        -- Force dots-only group buff style
+        TotemDeckDB.showGroupBuffStyle = "dots"
+
         -- Migration: Convert old string-based active totems to spell IDs
         if type(TotemDeckDB.activeEarth) == "string" then
             TotemDeckDB.activeEarth = MigrateTotemNameToID(TotemDeckDB.activeEarth) or defaults.activeEarth

--- a/TotemDeck.toc
+++ b/TotemDeck.toc
@@ -14,5 +14,6 @@ UI/Timers.lua
 UI/Reincarnation.lua
 UI/WeaponBuff.lua
 UI/Config.lua
+UI/Minimap.lua
 Events.lua
 Commands.lua

--- a/UI/ActionBar.lua
+++ b/UI/ActionBar.lua
@@ -110,6 +110,19 @@ function addon.CreateActionBarFrame()
         end
         btn.icon = icon
 
+        local pulse = icon:CreateAnimationGroup()
+        local scaleUp = pulse:CreateAnimation("Scale")
+        scaleUp:SetOrder(1)
+        scaleUp:SetDuration(0.12)
+        scaleUp:SetScale(1.2, 1.2)
+        scaleUp:SetSmoothing("OUT")
+        local scaleDown = pulse:CreateAnimation("Scale")
+        scaleDown:SetOrder(2)
+        scaleDown:SetDuration(0.12)
+        scaleDown:SetScale(1/1.2, 1/1.2)
+        scaleDown:SetSmoothing("IN")
+        btn.iconPulse = pulse
+
         -- Register for clicks BEFORE setting attributes
         btn:RegisterForClicks("AnyDown", "AnyUp")
 
@@ -177,6 +190,16 @@ function addon.CreateActionBarFrame()
                 else
                     GameTooltip:SetText(self.element .. " Totem", 1, 1, 1)
                 end
+                if TotemDeckDB.showGroupBuffCount ~= false then
+                    local totemIdentifier = self.placedSpellID or self.spellID or self.totemName
+                    if totemIdentifier then
+                        local buffed, total = addon.GetGroupTotemBuffCount(totemIdentifier)
+                        local buffText = addon.FormatGroupBuffCount(buffed, total)
+                        if buffText then
+                            GameTooltip:AddLine("Group buff: " .. buffText, 0.6, 0.8, 1)
+                        end
+                    end
+                end
                 GameTooltip:AddLine(" ")
                 GameTooltip:AddLine("Left-click to cast", 0.5, 0.5, 0.5)
                 GameTooltip:AddLine("Right-click to dismiss", 0.5, 0.5, 0.5)
@@ -226,6 +249,8 @@ function addon.CreateActionBarFrame()
         local iconTimerText = iconTimer:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
         iconTimerText:SetPoint("CENTER")
         iconTimerText:SetTextColor(1, 1, 1)
+        local fontFile, fontSize = GameFontNormalSmall:GetFont()
+        iconTimerText:SetFont(fontFile, (fontSize or 10) + 1, "OUTLINE")
 
         -- Function to update icon timer position based on timerPosition setting
         local function UpdateIconTimerPosition()
@@ -244,6 +269,18 @@ function addon.CreateActionBarFrame()
                 iconTimer:SetSize(40, 16)
                 iconTimer:SetPoint("LEFT", btn, "RIGHT", 2, 0)
             end
+            if btn.iconTimerDots then
+                btn.iconTimerDots:ClearAllPoints()
+                if pos == "BELOW" then
+                    btn.iconTimerDots:SetPoint("TOP", iconTimer, "BOTTOM", 0, -1)
+                elseif pos == "LEFT" then
+                    btn.iconTimerDots:SetPoint("RIGHT", iconTimer, "LEFT", -1, 0)
+                elseif pos == "RIGHT" then
+                    btn.iconTimerDots:SetPoint("LEFT", iconTimer, "RIGHT", 1, 0)
+                else
+                    btn.iconTimerDots:SetPoint("BOTTOM", iconTimer, "TOP", 0, 1)
+                end
+            end
         end
         UpdateIconTimerPosition()
 
@@ -251,6 +288,12 @@ function addon.CreateActionBarFrame()
         btn.iconTimerText = iconTimerText
         btn.UpdateIconTimerPosition = UpdateIconTimerPosition
         iconTimer:Hide()
+
+        local iconTimerDots = CreateFrame("Frame", nil, btn)
+        iconTimerDots:SetSize(18, 18)
+        iconTimerDots:SetPoint("BOTTOM", iconTimer, "TOP", 0, 1)
+        iconTimerDots:Hide()
+        btn.iconTimerDots = iconTimerDots
 
         -- Create popup column for this element (anchored to this button)
         addon.CreatePopupColumn(element, btn)

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -725,12 +725,12 @@ function addon.CreateConfigWindow()
     showMinimapCheck:SetPoint("TOPLEFT", 260, -148)
     showMinimapCheck:SetChecked(TotemDeckDB.showMinimapButton ~= false)
     showMinimapCheck:SetScript("OnClick", function(self)
-        TotemDeckDB.showMinimapButton = self:GetChecked()
+        TotemDeckDB.showMinimapButton = not not self:GetChecked()
         addon.UpdateMinimapButton()
     end)
     local showMinimapLabel = optionsSection:CreateFontString(nil, "OVERLAY", "GameFontNormal")
     showMinimapLabel:SetPoint("LEFT", showMinimapCheck, "RIGHT", 4, 0)
-    showMinimapLabel:SetText("Show minimap button")
+    showMinimapLabel:SetText("Show minimap button (reload)")
     frame.showMinimapCheck = showMinimapCheck
 
     --------------------------

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -459,14 +459,6 @@ function addon.CreateConfigWindow()
         addon.UpdateTimers()
     end)
 
-    frame.groupBuffStyleDropdown = CreateDropdown(settingsSection, "Buff Count Style", {
-        { label = "Numbers", value = "numbers" },
-        { label = "Dots", value = "dots" },
-    }, TotemDeckDB.showGroupBuffStyle or "numbers", 10, -70, function(value)
-        TotemDeckDB.showGroupBuffStyle = value
-        addon.UpdateTimers()
-    end)
-
     frame.popupModDropdown = CreateDropdown(settingsSection, "Popup Modifier", {
         { label = "None", value = "NONE" },
         { label = "Shift", value = "SHIFT" },
@@ -1480,9 +1472,6 @@ local function RefreshConfigWindowState()
     end
     if configWindow.showTooltipsCheck then
         configWindow.showTooltipsCheck:SetChecked(TotemDeckDB.showTooltips ~= false)
-    end
-    if configWindow.groupBuffStyleDropdown and configWindow.groupBuffStyleDropdown.UpdateValue then
-        configWindow.groupBuffStyleDropdown.UpdateValue(TotemDeckDB.showGroupBuffStyle or "numbers")
     end
     if configWindow.showGroupBuffCheck then
         configWindow.showGroupBuffCheck:SetChecked(TotemDeckDB.showGroupBuffCount ~= false)

--- a/UI/Minimap.lua
+++ b/UI/Minimap.lua
@@ -13,6 +13,12 @@ local function UpdateMinimapButtonPosition(button)
 end
 
 function addon.CreateMinimapButton()
+    if TotemDeckDB.showMinimapButton == false
+        or TotemDeckDB.showMinimapButton == 0
+        or TotemDeckDB.showMinimapButton == "0"
+        or TotemDeckDB.showMinimapButton == "false" then
+        return
+    end
     if addon.UI.minimapButton then
         addon.UpdateMinimapButton()
         return
@@ -48,6 +54,15 @@ function addon.CreateMinimapButton()
 
     btn:SetScript("OnClick", function()
         addon.ToggleConfigWindow()
+    end)
+
+    btn:SetScript("OnShow", function(self)
+        if TotemDeckDB.showMinimapButton == false
+            or TotemDeckDB.showMinimapButton == 0
+            or TotemDeckDB.showMinimapButton == "0"
+            or TotemDeckDB.showMinimapButton == "false" then
+            self:Hide()
+        end
     end)
 
     btn:SetScript("OnEnter", function(self)
@@ -87,10 +102,25 @@ end
 
 function addon.UpdateMinimapButton()
     local btn = addon.UI.minimapButton
-    if not btn then return end
+    if not btn then
+        if TotemDeckDB.showMinimapButton == false
+            or TotemDeckDB.showMinimapButton == 0
+            or TotemDeckDB.showMinimapButton == "0"
+            or TotemDeckDB.showMinimapButton == "false" then
+            return
+        end
+        addon.CreateMinimapButton()
+        return
+    end
 
-    if TotemDeckDB.showMinimapButton == false then
+    if TotemDeckDB.showMinimapButton == false
+        or TotemDeckDB.showMinimapButton == 0
+        or TotemDeckDB.showMinimapButton == "0"
+        or TotemDeckDB.showMinimapButton == "false" then
         btn:Hide()
+        btn:SetParent(nil)
+        btn:ClearAllPoints()
+        addon.UI.minimapButton = nil
         return
     end
 

--- a/UI/Minimap.lua
+++ b/UI/Minimap.lua
@@ -1,0 +1,99 @@
+-- TotemDeck: Minimap Button Module
+-- Quick access to config
+
+local addonName, addon = ...
+
+local function UpdateMinimapButtonPosition(button)
+    local angle = TotemDeckDB.minimapButtonPos or 220
+    local radius = 80
+    local rad = math.rad(angle)
+    local x = math.cos(rad) * radius
+    local y = math.sin(rad) * radius
+    button:SetPoint("CENTER", Minimap, "CENTER", x, y)
+end
+
+function addon.CreateMinimapButton()
+    if addon.UI.minimapButton then
+        addon.UpdateMinimapButton()
+        return
+    end
+
+    local btn = CreateFrame("Button", "TotemDeckMinimapButton", Minimap)
+    btn:SetSize(33, 33)
+    btn:SetFrameStrata("MEDIUM")
+    btn:SetFrameLevel(8)
+    btn:RegisterForClicks("AnyUp")
+
+    btn.bg = btn:CreateTexture(nil, "BACKGROUND")
+    btn.bg:SetSize(24, 24)
+    btn.bg:SetPoint("CENTER")
+    btn.bg:SetTexture("Interface\\Minimap\\MiniMap-TrackingBackground")
+
+    btn.icon = btn:CreateTexture(nil, "ARTWORK")
+    btn.icon:SetSize(18, 18)
+    btn.icon:SetPoint("CENTER", -1, 1)
+    btn.icon:SetTexture(addon.GetTotemIcon(8075) or 136097)
+    btn.icon:SetMask("Interface\\CharacterFrame\\TempPortraitAlphaMask")
+
+    btn.border = btn:CreateTexture(nil, "OVERLAY")
+    btn.border:SetTexture("Interface\\Minimap\\MiniMap-TrackingBorder")
+    btn.border:SetSize(52, 52)
+    btn.border:SetPoint("CENTER", btn, "CENTER", 11, -11)
+
+    local highlight = btn:SetHighlightTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
+    if highlight then
+        highlight:SetBlendMode("ADD")
+        highlight:SetAllPoints(btn)
+    end
+
+    btn:SetScript("OnClick", function()
+        addon.ToggleConfigWindow()
+    end)
+
+    btn:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_LEFT")
+        GameTooltip:SetText("TotemDeck", 1, 1, 1)
+        GameTooltip:AddLine("Click to open options", 0.7, 0.7, 0.7)
+        GameTooltip:Show()
+    end)
+
+    btn:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+
+    btn:SetScript("OnDragStart", function(self)
+        self.isDragging = true
+        self:SetScript("OnUpdate", function(s)
+            local mx, my = Minimap:GetCenter()
+            local cx, cy = GetCursorPosition()
+            local scale = UIParent:GetScale()
+            cx, cy = cx / scale, cy / scale
+            local angle = math.deg(math.atan2(cy - my, cx - mx))
+            TotemDeckDB.minimapButtonPos = angle
+            UpdateMinimapButtonPosition(s)
+        end)
+    end)
+
+    btn:SetScript("OnDragStop", function(self)
+        self.isDragging = false
+        self:SetScript("OnUpdate", nil)
+    end)
+
+    btn:RegisterForDrag("LeftButton")
+
+    addon.UI.minimapButton = btn
+    addon.UpdateMinimapButton()
+end
+
+function addon.UpdateMinimapButton()
+    local btn = addon.UI.minimapButton
+    if not btn then return end
+
+    if TotemDeckDB.showMinimapButton == false then
+        btn:Hide()
+        return
+    end
+
+    UpdateMinimapButtonPosition(btn)
+    btn:Show()
+end

--- a/UI/Popup.lua
+++ b/UI/Popup.lua
@@ -393,4 +393,46 @@ function addon.SetupPopupSystem()
             end
         end
     end)
+    addon.UI.popupUpdateFrame = updateFrame
+
+    local function AttachPopupLeaveHandlers()
+        for _, container in pairs(addon.UI.popupContainers or {}) do
+            if container and not container.totemDeckLeaveHooked then
+                container.totemDeckLeaveHooked = true
+                container:HookScript("OnLeave", function()
+                    if not TotemDeckDB.alwaysShowPopup then
+                        addon.state.popupHideToken = (addon.state.popupHideToken or 0) + 1
+                        local token = addon.state.popupHideToken
+                        C_Timer.After(0.15, function()
+                            if addon.state.popupHideToken ~= token then return end
+                            if addon.state.popupVisible and not addon.IsMouseOverPopupArea() then
+                                addon.HidePopup()
+                            end
+                        end)
+                    end
+                end)
+            end
+        end
+        for _, buttons in pairs(addon.UI.popupButtons or {}) do
+            for _, btn in ipairs(buttons) do
+                if btn and not btn.totemDeckLeaveHooked then
+                    btn.totemDeckLeaveHooked = true
+                    btn:HookScript("OnLeave", function()
+                        if not TotemDeckDB.alwaysShowPopup then
+                            addon.state.popupHideToken = (addon.state.popupHideToken or 0) + 1
+                            local token = addon.state.popupHideToken
+                            C_Timer.After(0.15, function()
+                                if addon.state.popupHideToken ~= token then return end
+                                if addon.state.popupVisible and not addon.IsMouseOverPopupArea() then
+                                    addon.HidePopup()
+                                end
+                            end)
+                        end
+                    end)
+                end
+            end
+        end
+    end
+
+    C_Timer.After(0, AttachPopupLeaveHandlers)
 end

--- a/UI/Timers.lua
+++ b/UI/Timers.lua
@@ -227,6 +227,8 @@ end
 
 -- Update timer bars
 function addon.UpdateTimers()
+    if not addon.UI then return end
+
     local timerFrame = addon.UI.timerFrame
     local timerBars = addon.UI.timerBars
     local activeTotemButtons = addon.UI.activeTotemButtons


### PR DESCRIPTION
## Summary
This PR improves visual feedback for active totems, both when they are placed and as they are about to expire.

## Changes
- Players affected by a totem buff within range are counted
- Coverage is visualized using small dots:
  - As a row of dots inside the bar
  - As dice-style dots on the icon
- Improved timer text color for expiring totems
- Bar and icon start pulsing shortly before the totem expires
- Added a short pulsing effect when a totem is placed
- Added minimap button

## Motivation
These visual cues make it easier to:
- See how many players are currently benefiting from a totem
- Notice newly placed and expiring totems at a glance without relying solely on the timer

All changes are visual-only and do not affect existing gameplay mechanics.

## Compatibility
- No breaking changes
- Visual-only enhancements
- Tested in-game

## Personal note
I originally made these changes just for myself in my fork.  
After using them for a while, I thought they might be useful for others as well,  
so I decided to open this PR instead of keeping them private 🙂

Thanks for maintaining this addon ❤️